### PR TITLE
Docfixes

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -13,7 +13,7 @@ our extensions have been made, but none succeeded.
 
 Bento is born out of this experience. We also believe that current solutions
 based on distutils suffer a lot of NIH, and ignore lessons learned in packaging
-in most other systems.  Bento aims at shamelessly copy what works in other
+in most other systems.  Bento aims at shamelessly copying what works in other
 systems (CPAN, CRAN, JSAN, HackageDB).
 
 What are the goals of bento ?
@@ -42,7 +42,7 @@ distutils is deeply flawed:
       but knowing the install prefix at build time is often useful.
     - There is no developer documentation, and what consitutes public API is
       not documented either. Consequently, every non trivial distutils
-      extension relies on internal details, and as such are fragile.
+      extension relies on internal details, and as such is fragile.
     - Extending by inheritence does not work well: when two modules A and B
       extend distutils, it becomes difficult for B to reuse A (for example,
       dealing with setuptools in numpy.distutils extensions has been a constant
@@ -50,7 +50,7 @@ distutils is deeply flawed:
     - Customizing compilation flags, and more generally some tools involved in
       compilation is too complicated. For example, adding a new tool in the
       build chain requires rewriting the build command, which is aggravated by
-      the previous issue. We believe fixing this would end up to rewriting the
+      the previous issue. We believe fixing this would end up in rewriting the
       whole thing.
     - Improving distutils to handle dependencies automatically (rebuild only
       the necessary .c files) is difficult because of the way distutils is
@@ -82,7 +82,7 @@ India in december 2009).
 
 Starting from the distutils codebase is not very appealing, as most of it would
 need to be scrapped (at least the whole command and compiler business needs to
-be completely rewritten). There are also irreconciliable differences on some
+be completely rewritten). There are also irreconcilable differences on some
 key points. In particular, we think the following features are essential:
 
     1. specified and versioned metadata formats, instead of implementation
@@ -96,9 +96,9 @@ key points. In particular, we think the following features are essential:
 Although controversial in the python community, there is a large consensus
 within the scipy community on those points.  Some of them have been rejected by
 various distutils2 members (2, 3 and 4 in particular), and we are unwilling to
-compromize on them. Distutils-related PEP pushed by the distutils2 team will be
-implemented on a case per case basis (some of them are obsolete as far as bento
-is concerned, in the sense that they are already implemented, if only in
+compromise on them. Distutils-related PEPs pushed by the distutils2 team will
+be implemented on a case per case basis (some of them are obsolete as far as
+bento is concerned, in the sense that they are already implemented, if only in
 intent).
 
 Moreover, as bento is designed from the ground up to be split into mostly
@@ -117,7 +117,7 @@ non-Unix platforms), most of this knowledge actually comes from autoconf
 through the sysconfig module.
 
 Any non-superficial modification of the C compilation part of distutils will
-also require to rework the platform-specific knowledge anyway.
+also require reworking the platform-specific knowledge anyway.
 
 What about existing projects using distutils ?
 ==============================================
@@ -135,7 +135,7 @@ the build and installation.
 Is bento based on existing tools ?
 ====================================
 
-The main inspirations for bento current design are taken from:
+The main inspirations for bento's current design are taken from:
 
     - `Cabal`_, the packaging tool for Haskell: the bento file format is
       mainly an adaptation of Cabal to python.

--- a/doc/source/guides.rst
+++ b/doc/source/guides.rst
@@ -84,9 +84,9 @@ Retrieving data files at runtime
 It is often necessary to retrieve data files from your python code.
 For example, you may have a configuration file which needs to be read
 at startup. The simplest way to do so is to use __file__ and refer to
-data files relatively to python code. This is not very flexible,
-because it requires to deal with platform idiosyncraties w.r.t. files
-location.  Setuptools and its descendents has an alternative mechanism
+data files relative to python code. This is not very flexible,
+because it requires dealing with platform idiosyncraties w.r.t. file
+location.  Setuptools and its descendents have an alternative mechanism
 to retrieve resources at runtime, implemented in the pkg_resource
 module.
 
@@ -104,8 +104,7 @@ The file looks as follows::
     SHAREDSTATEDIR = "/usr/local/com"
     ...
 
-So you can import every path variable with their expanded value in
-your package::
+So you can import every path variable with its expanded value in your package::
 
     try:
         from foo.__bento_config import DOCDIR, SHAREDSTATEDIR
@@ -183,8 +182,8 @@ complex packages may require a more advanced configuration, e.g.:
       or even make).
     * add new options to an existing command
 
-Instead of craming too many features in the bento.info, bento allows you to add
-one (or more) "hook" files, which are regular python modules, but under the
+Instead of cramming too many features in the bento.info, bento allows you to
+add one (or more) "hook" files, which are regular python modules, but under the
 control of bento.
 
 Simple example: hello world
@@ -202,7 +201,7 @@ the hook file will look like::
         print "Yummy bento"
 
 As its name suggests, the startup method is executed before running any
-command, and before bentomaker itself parse the command line. As such, you do
+command, and before bentomaker itself parses the command line. As such, you do
 not want to do to many things there -- typically register new commands.
 
 Command hook and bento context
@@ -233,10 +232,10 @@ configure -> bento.commands.configure.Configure class). cmd_opts is a simple lis
     def pconfigure(ctx):
         print ctx.cmd_opts
 
-Each ctx variable also have a pkg member, which is a
+Each ctx variable also has a pkg member, which is a
 PackageDescription instance, and contains most package information.
 Metadata, extensions, path options, executables are all available,
-which enable the following:
+which enables the following:
 
     * access package information to generate new "targets" (new types
       of binary installers)
@@ -260,7 +259,7 @@ easier.
 
 *Note: unfortunately, there is still no public API for safe
 PackageDescription instances access. Most read access should be safe,
-but modifying package description members likely to break in the
+but modifying package description members is likely to break in the
 future*
 
 Hook and recursive package definitions
@@ -292,8 +291,8 @@ through this mechanism. Env can contain any key as used by yaku (that
 includes the compiler, compiler flags, etc...), but note that new
 flags are appended to existing values.
 
-You can also register entirely new builder for a given extension. This
-requires dealing with yaku relatively low-level API, but it enables
+You can also register an entirely new builder for a given extension. This
+requires dealing with yaku's relatively low-level API, but it enables
 basically any kind of transformation, like compiling each source
 differently, associating new tools to existing source suffix, etc....
 This is unfortunately the only way to override environments ATM::

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -4,7 +4,7 @@ Overview
 Bento is based on a declarative package description, which is parsed by the
 different build tools to do the actual work. There are currently two ways to
 create such a package description: by writing it from scratch, or by converting
-existing setup.py.
+an existing setup.py.
 
 Simple example
 --------------
@@ -57,7 +57,7 @@ this is not done automatically (yet).
 From existing setup.py
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Bentomaker has an experimental convert command to convert existing setup.py::
+Bentomaker has an experimental convert command to convert an existing setup.py::
 
     bentomaker convert
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -39,17 +39,17 @@ Building and installing
 Bento includes bentomaker, a command-line interface to configure, build and
 install simple packages. Its interface is similar to autotools::
 
-    bento configure --prefix=somedirectory
-    bento build
-    bento install
+    bentomaker configure --prefix=somedirectory
+    bentomaker build
+    bentomaker install
 
 In addition, the following subcommands are available::
 
-    bento sdist
+    bentomaker sdist
 
 to build a source distribution and::
 
-    bento build_egg
+    bentomaker build_egg
 
 to build an egg. Building an egg requires to run configure and build first -
 this is not done automatically (yet).

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -19,7 +19,7 @@ A typical .info file contains the following information:
 
     * The package metadata (name, version, etc...)
     * Optionally, it may contain addition user-customizable options such as
-      path or flags, which exact value may be set at configure time.
+      path or flags, whose exact value may be set at configure time.
     * A Library section, which defines the package content (packages, modules,
       C extensions, etc...)
     * Optionally, the .info file may contain one or several Executable
@@ -303,9 +303,9 @@ Bentomaker has a basic help facility::
     bentomaker help
 
 will list all available commands. Once the project is configured, every
-installation path and user customization is setup, and cannot be changed
-(except by reconfiguring the package, of course). Bentomaker is still in infancy,
-and quite limited:
+installation path and user customization is set up, and cannot be changed
+(except by reconfiguring the package, of course). Bentomaker is still in its
+infancy, and quite limited:
 
     - it will complain when you try to install without having run build first (it
       will not automatically run build for you).
@@ -320,7 +320,7 @@ Available commands
 configure
 ---------
 
-This commands must be run before any build/install command. It is similar to
+This command must be run before any build/install command. It is similar to
 the well-known configure script from autoconf. Every customizable option is
 available from the command help::
 
@@ -355,7 +355,7 @@ This simply produces a source tarball. Currently, only .tar.gz is supported.
 convert
 -------
 
-This convert a package built from distutils, setuptools or numpy.distutils::
+This converts a package built from distutils, setuptools or numpy.distutils::
 
     bentomaker convert
 


### PR DESCRIPTION
Hey David, finally found the time to dive in. Very nice! Here's some doc fixes I noticed.

Tried your bento_build branch of numpy as well. Build finishes smoothly, although I noticed it builds x86_64 arch while python (standard from python.org) does not support it. Installation seems to work too, but the end result can not be imported - **config**.py is missing. The docs do not explain how to install such a file, since it's generated at configure? time only.
