### PR TITLE
Fix build_mpkg

### DIFF
--- a/bento/commands/build_mpkg.py
+++ b/bento/commands/build_mpkg.py
@@ -21,6 +21,9 @@ from bento.commands.core \
 from bento.commands.mpkg_utils \
     import \
         build_pkg, PackageInfo, MetaPackageInfo, make_mpkg_plist, make_mpkg_description
+from bento.core.utils \
+    import \
+        MODE_755
 
 def get_default_scheme(pkg_name, py_version_short=None, prefix=None):
     if py_version_short is None:
@@ -117,6 +120,8 @@ def build_pkg_from_temp(ctx, ipkg, pkg_root, root_node, install_root, categories
                 #    os.makedirs(os.path.dirname(target))
                 target.parent.mkdir()
                 shutil.copy(source.abspath(), target.abspath())
+                if kind == "executables":
+                    os.chmod(target.abspath(), MODE_755)
 
         pkg_name = os.path.splitext(os.path.basename(pkg_root))[0]
         pkg_info = PackageInfo(pkg_name=pkg_name,

--- a/bento/commands/mpkg_utils.py
+++ b/bento/commands/mpkg_utils.py
@@ -55,7 +55,7 @@ def common_description(pkg_info):
 def unicode_path(path, encoding=sys.getfilesystemencoding()):
     if isinstance(path, six.text_type):
         return path
-    return six.u(path, encoding)
+    return unicode(path, encoding)
 
 def write(dct, path):
     p = plistlib.Plist()

--- a/bento/commands/mpkg_utils.py
+++ b/bento/commands/mpkg_utils.py
@@ -26,7 +26,7 @@ def common_info(pkg_info):
     name = unicode(pkg_info.name)
     major, minor = pkg_info.version_info[0], pkg_info.version_info[1]
     version = pkg_info.version
-    return dict(
+    defaults = dict(
         CFBundleGetInfoString='%s %s' % (name, version),
         CFBundleIdentifier='org.pythonmac.%s' % (name,),
         CFBundleName=name,

--- a/bento/private/_six/six.py
+++ b/bento/private/_six/six.py
@@ -230,7 +230,10 @@ else:
     def b(s):
         return s
     def u(s):
-        return unicode(s, "unicode_escape")
+        if type(s) is not unicode:
+            return unicode(s, "unicode_escape")
+        else:
+            return s
     import StringIO
     StringIO = BytesIO = StringIO.StringIO
 _add_doc(b, """Byte literal""")


### PR DESCRIPTION
The build_mpkg functionality was broken in the latest master.
I fixed two things:
1) the installed entry point was not executable
2) there was an issue with unicode conversion, it is now fixed but I modified six.py, which feels a bit wrong (but looked like the right thing to do)

After these commits, build_mpkg worked just fine, thanks!
